### PR TITLE
Add JWTPLUGIN_API to UJWTPluginBPLibrary class

### DIFF
--- a/Source/JWTPlugin/Public/JWTPluginBPLibrary.h
+++ b/Source/JWTPlugin/Public/JWTPluginBPLibrary.h
@@ -10,7 +10,7 @@
 
 
 UCLASS()
-class UJWTPluginBPLibrary : public UBlueprintFunctionLibrary
+class JWTPLUGIN_API UJWTPluginBPLibrary : public UBlueprintFunctionLibrary
 {
 	GENERATED_UCLASS_BODY()
 


### PR DESCRIPTION
Making this change got rid of a LNK2019 error I got when trying to call UJWTPluginBPLibrary::GetClaims from C++ code.